### PR TITLE
 fixes issue for service url as header parameter forward

### DIFF
--- a/config/local/values.yml
+++ b/config/local/values.yml
@@ -11,6 +11,10 @@ server.serviceId: light-mesh-1.0.0
 ## proxy yaml
 proxy.containerPort: '8080'
 
+router.hostWhitelist:
+  - 192.168.0.*
+  - localhost
+
 
 ## handler yaml
 handler.enabled: true

--- a/src/main/resources/config/router.yml
+++ b/src/main/resources/config/router.yml
@@ -20,3 +20,6 @@ reuseXForwarded: false
 
 # Max Connection Retries
 maxConnectionRetries: 3
+
+# allowed host list. Use Regex to do wildcard match
+hostWhitelist: ${router.hostWhitelist:}


### PR DESCRIPTION
router.hostWhitelist:
required for service_url traffic routing